### PR TITLE
fix: Correct system prompt path resolution for Cursor Agent

### DIFF
--- a/apps/api/app/services/cli/unified_manager.py
+++ b/apps/api/app/services/cli/unified_manager.py
@@ -18,7 +18,8 @@ import base64
 def get_project_root() -> str:
     """Get project root directory using relative path navigation"""
     current_file_dir = os.path.dirname(os.path.abspath(__file__))
-    # unified_manager.py -> cli -> services -> app -> api -> apps -> project-root
+    # unified_manager.py is in: app/services/cli/
+    # Navigate: cli -> services -> app -> api -> apps -> project-root
     project_root = os.path.join(current_file_dir, "..", "..", "..", "..", "..")
     return os.path.abspath(project_root)
 
@@ -1026,8 +1027,9 @@ class CursorAgentCLI(BaseCLI):
         try:
             # Read system prompt from the source file using relative path
             current_file_dir = os.path.dirname(os.path.abspath(__file__))
-            # unified_manager.py -> cli -> services -> app
-            app_dir = os.path.join(current_file_dir, "..", "..", "..")
+            # unified_manager.py is in: app/services/cli/
+            # Navigate: cli -> services -> app
+            app_dir = os.path.join(current_file_dir, "..", "..")
             app_dir = os.path.abspath(app_dir)
             system_prompt_path = os.path.join(app_dir, "prompt", "system-prompt.md")
             


### PR DESCRIPTION
## Summary
- Fixed incorrect path calculation that caused "System prompt file not found" warnings for Cursor Agent
- The path navigation was off by one level (`cli -> services -> app` instead of `cli -> services`)
- Updated comments to clarify the actual directory structure

## Problem
Cursor Agent was looking for system prompt at:
```
/Users/tachyon/project/Claudable/apps/api/prompt/system-prompt.md
```

But the file actually exists at:
```
/Users/tachyon/project/Claudable/apps/api/app/prompt/system-prompt.md
```

## Solution
Fixed the relative path calculation in `unified_manager.py` from navigating 3 levels up to 2 levels up, which correctly points to the `app` directory.

## Test Result
After the fix, AGENT.md is successfully created without any warnings:
```
📝 [Cursor] Created AGENT.md at: .../repo/AGENT.md
```

## Note
This issue only affected Cursor Agent, not Claude Code.