### PR TITLE
feat: support optional Lite Harness CLI provider

### DIFF
--- a/lib/services/cli/agent-sdk.ts
+++ b/lib/services/cli/agent-sdk.ts
@@ -1,0 +1,56 @@
+import { query as claudeAgentQuery } from '@anthropic-ai/claude-agent-sdk';
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+
+export type { SDKMessage };
+
+type QueryArgs = Parameters<typeof claudeAgentQuery>[0];
+type QueryReturn = ReturnType<typeof claudeAgentQuery>;
+type QueryFunction = (args: QueryArgs) => QueryReturn;
+type LiteHarnessOptions = QueryArgs['options'] & {
+  agent?: string;
+  harness?: string;
+};
+
+const LITE_HARNESS_PROVIDER = 'lite-harness';
+const LITE_HARNESS_DEFAULT_HARNESS = 'claude-code';
+
+function getProvider() {
+  return (process.env.CLAUDABLE_AGENT_SDK_PROVIDER || 'claude-agent-sdk')
+    .trim()
+    .toLowerCase();
+}
+
+function withLiteHarnessOptions(args: QueryArgs): QueryArgs {
+  const options = (args.options || {}) as LiteHarnessOptions;
+
+  return {
+    ...args,
+    options: {
+      ...options,
+      harness:
+        process.env.LITE_HARNESS_HARNESS ||
+        process.env.LITE_HARNESS_AGENT ||
+        options.harness ||
+        options.agent ||
+        LITE_HARNESS_DEFAULT_HARNESS,
+      ...(process.env.LITE_HARNESS_MODEL
+        ? { model: process.env.LITE_HARNESS_MODEL }
+        : {}),
+    } as QueryArgs['options'],
+  };
+}
+
+async function loadQuery(): Promise<QueryFunction> {
+  if (getProvider() !== LITE_HARNESS_PROVIDER) {
+    return claudeAgentQuery;
+  }
+
+  const liteHarnessPackage = process.env.LITE_HARNESS_PACKAGE || '@lite-harness/sdk';
+  const liteHarness = (await import(liteHarnessPackage)) as {
+    query: QueryFunction;
+  };
+
+  return (args) => liteHarness.query(withLiteHarnessOptions(args));
+}
+
+export const query = await loadQuery();

--- a/lib/services/cli/claude.ts
+++ b/lib/services/cli/claude.ts
@@ -4,7 +4,7 @@
  * Interacts with projects using the Claude Agent SDK.
  */
 
-import { query, type SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import { query, type SDKMessage } from './agent-sdk';
 import type { ClaudeSession, ClaudeResponse } from '@/types/backend';
 import { streamManager } from '../stream';
 import { serializeMessage, createRealtimeMessage } from '@/lib/serializers/chat';

--- a/lib/services/cli/glm.ts
+++ b/lib/services/cli/glm.ts
@@ -3,7 +3,7 @@
  * Minimal Claude Agent SDK integration configured for Zhipu GLM models.
  */
 
-import { query } from '@anthropic-ai/claude-agent-sdk';
+import { query } from './agent-sdk';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';


### PR DESCRIPTION
## Summary

Adds a small local Agent SDK adapter for Claudable's CLI services. The default path still uses `@anthropic-ai/claude-agent-sdk`, so current Claude and GLM flows keep the same behavior.

When `CLAUDABLE_AGENT_SDK_PROVIDER=lite-harness` is set, the adapter loads Lite Harness and keeps the existing `query()` call sites while allowing the runtime harness to be selected either in code or with env vars.

## Swap harnesses in code

The CLI services can keep importing the local adapter:

```ts
import { query } from './agent-sdk';
```

Then callers can choose the harness at the call site:

```ts
await query({
  prompt,
  options: {
    harness: 'claude-code',
  },
});

await query({
  prompt,
  options: {
    harness: 'codex',
  },
});

await query({
  prompt,
  options: {
    harness: 'pi-ai',
  },
});
```

The default remains Claude Agent SDK unless `CLAUDABLE_AGENT_SDK_PROVIDER=lite-harness` is enabled. `LITE_HARNESS_HARNESS` can also set the default harness for existing call sites without touching each query call.

## Why

I am a LiteLLM maintainer, and we are working on Lite Harness to solve the agent harness problem: letting developers keep one common SDK shape while swapping the runtime harness they want to use.

Claudable already supports multiple local CLI agents, and these two services already route through the Claude Agent SDK `query()` shape. This PR keeps that code path stable while making Claude Code, Codex, PI AI, or another Lite Harness runtime a small adapter/config choice. We would love feedback on whether this is useful for Claudable's agent runtime workflow.

## How to try it

Default behavior remains unchanged.

Try Lite Harness after installing/packing the preview SDK in your environment:

```bash
CLAUDABLE_AGENT_SDK_PROVIDER=lite-harness \
LITE_HARNESS_HARNESS=codex \
LITE_HARNESS_MODEL=gpt-5.5 \
npm run dev
```

Swap `LITE_HARNESS_HARNESS` to `claude-code`, `codex`, or `pi-ai` to choose the harness without changing the app command.

## Verification

- `PATH="/Users/ishaanjaffer/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm ci`
- `PATH="/Users/ishaanjaffer/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run type-check`
- `git diff --check`

Note: `npm ci` reports existing dependency audit findings and runs the repo postinstall setup, which creates local `.env` files. No env files are included in this PR.
